### PR TITLE
使用官方 FastMCP SDK 重構 MCP 後端

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,65 +20,104 @@
 ### 1. 環境準備
 
 *   **Git**: 用於克隆儲存庫。
-*   **Python**: 版本需 >= 3.10。
-*   **(推薦) uv**: 一個快速的 Python 套件安裝與管理工具 ([安裝指南](https://github.com/astral-sh/uv))。如果沒有 `uv`，也可以使用 Python 內建的 `venv` 和 `pip`。
+*   **Python**: 版本需 >= 3.8。
+*   **MCP SDK**: 官方 MCP 開發套件。
 
 ### 2. 安裝步驟
 
 ```bash
 # 1. 克隆儲存庫
-git clone <您的儲存庫 URL>
-cd southAsia_Tool # 進入專案目錄
+git clone https://github.com/igs-pochenkuo/southasia_mcp.git
+cd southasia_mcp # 進入專案目錄
 
 # 2. 建立並啟用虛擬環境
-# 使用 uv (推薦)
-uv venv
+python -m venv .venv
 source .venv/bin/activate  # Linux/macOS
 # 或者 .\.venv\Scripts\Activate.ps1  # Windows PowerShell
 # 或者 .\.venv\Scripts\activate.bat # Windows Cmd
 
-# 使用 Python 內建 venv
-# python -m venv .venv
-# source .venv/bin/activate  # Linux/macOS
-# 或者 .\.venv\Scripts\Activate.ps1  # Windows PowerShell
-# 或者 .\.venv\Scripts\activate.bat # Windows Cmd
-
 # 3. 安裝依賴
-# 使用 uv (推薦)
-uv pip sync pyproject.toml
-
-# 4. 使用 pip 編譯工具
-pip install -e .
+pip install -r requirements.txt
 ```
 
-### 3. 設定 Cursor MCP 工具
+### 3. 使用方式
 
-1.  **找到 Cursor 設定檔**:
-    *   通常位於使用者家目錄下的 `.cursor` 資料夾中。
-    *   Windows: `%USERPROFILE%\.cursor\mcp.json`
-    *   macOS/Linux: `~/.cursor/mcp.json`
-2.  **編輯 `mcp.json`**:
-    *   如果檔案不存在，請建立它。
-    *   加入以下內容 (如果已有其他工具，請確保 JSON 格式正確)：
+本專案提供兩種使用方式：
 
-    ```json
-    {
-      "southAsia": {
-        "command": "cmd", // 或 "bash", "zsh" 等，依您的系統
-        "args": [
-          "/c", // Windows cmd 的參數，bash/zsh 通常不需要
-          "southasia" // 對應 pyproject.toml 中定義的命令名稱
-        ]
-      }
-    }
-    ```
-    *   **重要**:
-        *   `"southAsia"`: 這是你在 Cursor 中 `@` 後面輸入的工具名稱，必須與 `server.py` 中的 `MCP_TOOL_NAME` (或您修改後的名稱) **大小寫一致**。
-        *   `"southasia"`: 這是您在步驟 2 安裝後可在終端運行的命令，對應 `pyproject.toml` 中 `[project.scripts]` 的設定 (建議小寫)。
-        *   `command` 和 `args`: 請根據您的作業系統和 Shell 調整。Windows PowerShell 可能需要不同的參數。
-3.  **重啟 Cursor**: 關閉並重新開啟 Cursor 以載入新的 MCP 工具設定。
+#### 方式一：使用 FastAPI 網頁應用程式
 
-### 4. 測試安裝
+這是推薦的使用方式，提供了直觀的網頁界面和 API 端點。
+
+```bash
+# 啟動網頁應用程式
+python new_web_app.py
+```
+
+啟動後，打開瀏覽器訪問 http://localhost:12001 即可使用網頁界面。
+
+#### 方式二：使用傳統命令行工具
+
+如果您偏好命令行方式，可以使用以下步驟：
+
+```bash
+# 安裝為命令行工具
+pip install -e .
+
+# 使用命令行工具
+southasia
+```
+
+### 4. 在 Cursor 中使用 MCP
+
+#### 方式一：使用 FastAPI 網頁應用程式（推薦）
+
+1. **啟動 MCP 服務**：
+   ```bash
+   python new_web_app.py
+   ```
+
+2. **配置 Cursor**：
+   - 打開 Cursor 編輯器
+   - 進入設置 (Settings)，找到 "AI" 或 "Extensions" 部分
+   - 在 "Local MCP Studio" 或 "MCP 設置" 中，配置以下參數：
+     - MCP 服務地址：`http://localhost:12001`
+     - 啟用本地 MCP 服務：開啟
+
+3. **測試連接**：
+   - 在 Cursor 中打開命令面板 (通常是 Cmd/Ctrl+Shift+P)
+   - 輸入 "Test MCP Connection" 或 "測試 MCP 連接"
+   - 如果配置正確，應該會看到成功連接的提示
+
+#### 方式二：使用傳統命令行工具
+
+1. **找到 Cursor 設定檔**:
+   - 通常位於使用者家目錄下的 `.cursor` 資料夾中。
+   - Windows: `%USERPROFILE%\.cursor\mcp.json`
+   - macOS/Linux: `~/.cursor/mcp.json`
+
+2. **編輯 `mcp.json`**:
+   - 如果檔案不存在，請建立它。
+   - 加入以下內容 (如果已有其他工具，請確保 JSON 格式正確)：
+
+   ```json
+   {
+     "southAsia": {
+       "command": "cmd", // 或 "bash", "zsh" 等，依您的系統
+       "args": [
+         "/c", // Windows cmd 的參數，bash/zsh 通常不需要
+         "southasia" // 對應 pyproject.toml 中定義的命令名稱
+       ]
+     }
+   }
+   ```
+   - **重要**:
+       - `"southAsia"`: 這是你在 Cursor 中 `@` 後面輸入的工具名稱，必須與 `server.py` 中的 `MCP_TOOL_NAME` (或您修改後的名稱) **大小寫一致**。
+       - `"southasia"`: 這是您在步驟 2 安裝後可在終端運行的命令，對應 `pyproject.toml` 中 `[project.scripts]` 的設定 (建議小寫)。
+       - `command` 和 `args`: 請根據您的作業系統和 Shell 調整。Windows PowerShell 可能需要不同的參數。
+
+3. **重啟 Cursor**: 關閉並重新開啟 Cursor 以載入新的 MCP 工具設定。
+
+### 5. 測試 MCP 工具
 
 在 Cursor 的聊天視窗中輸入：
 
@@ -86,7 +125,7 @@ pip install -e .
 @southAsia mcp_hello_world
 ```
 
-如果看到類似 "Hello World! 這是您的第一個 SouthAsia 工具！" 的回應，表示安裝和設定成功！
+或者，如果您使用的是網頁應用程式方式，可以直接在網頁界面上點擊「執行」按鈕測試工具。
 
 您也可以測試帶參數的工具：
 
@@ -130,14 +169,37 @@ pip install -e .
 
 如果在安裝、設定或使用過程中遇到問題，可以嘗試以下步驟：
 
+### 一般問題
+
 *   **確認虛擬環境**: 確保你已經在專案的虛擬環境中執行安裝和運行命令。
-*   **檢查 Cursor 設定 (`mcp.json`)**:
+*   **檢查 Cursor 設定**:
     *   仔細核對工具集名稱 (例如 `"southAsia"`) 是否與 `server.py` 中的 `MCP_TOOL_NAME` **大小寫完全一致**。
     *   確認 `args` 中的命令行工具名稱 (例如 `"southasia"`) 是否與 `pyproject.toml` 中 `[project.scripts]` 定義的**大小寫完全一致**。
     *   檢查 `command` 和 `args` 是否適合你的作業系統和 Shell 環境。
-*   **手動運行服務器**: 在**已啟用虛擬環境**的終端中，直接運行 `southasia` (或你修改後的命令)。觀察是否有任何錯誤訊息或日誌輸出。這有助於判斷 MCP 服務本身是否能正常啟動。
 *   **檢查 Cursor 輸出**: 查看 Cursor 的「輸出」(Output) 面板，有時 MCP 相關的錯誤會顯示在那裡。
-*   **重啟 Cursor**: 在修改 `mcp.json` 或重新安裝後，重啟 Cursor。
+*   **重啟 Cursor**: 在修改設定或重新安裝後，重啟 Cursor。
+
+### 網頁應用程式特定問題
+
+*   **端口被占用**:
+    *   使用不同的端口啟動應用程式：`PORT=12002 python new_web_app.py`
+    *   或終止占用端口的進程後重試
+
+*   **MCP SDK 版本兼容性問題**:
+    *   如果遇到 `AttributeError: 'FastMCP' object has no attribute 'xxx'` 錯誤，這是由於不同版本的 MCP SDK API 差異導致
+    *   本應用程式已內建兼容性處理，但如果仍然遇到問題，請檢查您的 MCP SDK 版本並參考相應文檔
+    *   您可以嘗試更新到最新版本的 MCP SDK：`pip install --upgrade mcp`
+
+*   **asyncio 衝突問題**:
+    *   如果遇到 `Already running asyncio in this thread` 錯誤，這是因為 FastAPI 和 FastMCP 都使用 asyncio 事件循環導致的衝突
+    *   最新版本的應用程式已使用多進程代替多線程來啟動 MCP 服務，解決了這個問題
+    *   如果仍然遇到問題，請嘗試重新安裝 MCP SDK：`pip uninstall mcp -y && pip install mcp`
+
+### 命令行工具特定問題
+
+*   **手動運行服務器**: 在**已啟用虛擬環境**的終端中，直接運行 `southasia` (或你修改後的命令)。觀察是否有任何錯誤訊息或日誌輸出。這有助於判斷 MCP 服務本身是否能正常啟動。
+*   **檢查依賴安裝**: 確保所有依賴都已正確安裝，可以嘗試重新運行 `pip install -e .`。
+*   **檢查 Python 版本**: 確保您使用的 Python 版本符合要求 (>= 3.8)。
 
 ## 📄 授權條款
 

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -192,6 +192,11 @@ async def 新工具函數(參數1: str, 參數2: int) -> List[TextContent]:
   - 本應用程式已內建兼容性處理，但如果仍然遇到問題，請檢查您的 MCP SDK 版本並參考相應文檔
   - 您可以嘗試更新到最新版本的 MCP SDK：`pip install --upgrade mcp`
 
+- **asyncio 衝突問題**：
+  - 如果遇到 `Already running asyncio in this thread` 錯誤，這是因為 FastAPI 和 FastMCP 都使用 asyncio 事件循環導致的衝突
+  - 最新版本的應用程式已使用多進程代替多線程來啟動 MCP 服務，解決了這個問題
+  - 如果仍然遇到問題，請嘗試重新安裝 MCP SDK：`pip uninstall mcp -y && pip install mcp`
+
 ## 貢獻與支持
 
 歡迎提交問題報告、功能請求或貢獻代碼。請通過 GitHub Issues 或 Pull Requests 參與項目開發。

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -197,6 +197,56 @@ async def 新工具函數(參數1: str, 參數2: int) -> List[TextContent]:
   - 最新版本的應用程式已使用多進程代替多線程來啟動 MCP 服務，解決了這個問題
   - 如果仍然遇到問題，請嘗試重新安裝 MCP SDK：`pip uninstall mcp -y && pip install mcp`
 
+## 在 Cursor 中使用 MCP
+
+[Cursor](https://cursor.sh/) 是一款基於 AI 的程式編輯器，您可以將本專案的 MCP 服務與 Cursor 整合，實現更強大的開發體驗。
+
+### 設置步驟
+
+1. **啟動 MCP 服務**：
+   - 首先啟動本專案的 MCP 服務：`python new_web_app.py`
+   - 確認服務正常運行在 http://localhost:12001
+
+2. **配置 Cursor**：
+   - 打開 Cursor 編輯器
+   - 進入設置 (Settings)，找到 "AI" 或 "Extensions" 部分
+   - 在 "Local MCP Studio" 或 "MCP 設置" 中，配置以下參數：
+     - MCP 服務地址：`http://localhost:12001`
+     - 啟用本地 MCP 服務：開啟
+
+3. **測試連接**：
+   - 在 Cursor 中打開命令面板 (通常是 Cmd/Ctrl+Shift+P)
+   - 輸入 "Test MCP Connection" 或 "測試 MCP 連接"
+   - 如果配置正確，應該會看到成功連接的提示
+
+### 使用方法
+
+1. **直接在編輯器中使用 MCP 工具**：
+   - 在編輯代碼時，可以通過 Cursor 的 AI 功能調用已註冊的 MCP 工具
+   - 例如，可以在命令面板中輸入 "Run MCP Tool: mcp_hello_name" 並提供參數
+
+2. **通過 Cursor 擴展 API 調用**：
+   - 如果您正在開發 Cursor 擴展，可以使用以下 API 調用 MCP 工具：
+   ```javascript
+   // 示例代碼 (JavaScript)
+   const response = await cursor.mcp.callTool("mcp_hello_name", { name: "張三" });
+   console.log(response);
+   ```
+
+3. **故障排除**：
+   - 確保 MCP 服務已啟動並正常運行
+   - 檢查 Cursor 中的 MCP 服務地址配置是否正確
+   - 如果遇到連接問題，可以嘗試重啟 MCP 服務和 Cursor
+
+### 進階整合
+
+如果您想要開發自己的 MCP 工具並在 Cursor 中使用：
+
+1. 按照前面的 "添加新工具" 部分在本專案中註冊新工具
+2. 重啟 MCP 服務以使新工具生效
+3. 在 Cursor 中刷新 MCP 工具列表 (通常在命令面板中有相應選項)
+4. 新工具將可在 Cursor 中使用
+
 ## 貢獻與支持
 
 歡迎提交問題報告、功能請求或貢獻代碼。請通過 GitHub Issues 或 Pull Requests 參與項目開發。

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -1,116 +1,194 @@
-# SouthAsia MCP Web 應用程序
+# SouthAsia MCP 工具網頁應用
 
-這是一個基於 FastAPI 和 FastMCP 的 Web 應用程序，用於與 SouthAsia MCP 工具進行交互。
+這是一個基於 FastAPI 和官方 Python MCP SDK (FastMCP) 開發的網頁應用程式，提供簡潔直觀的使用者介面，讓您能夠輕鬆管理和使用 SouthAsia MCP 工具。
 
-## 功能特點
+## 主要特色
 
-- 使用官方 Python MCP SDK (FastMCP) 實現
-- 提供簡潔的 Web 界面來管理 MCP 服務
-- 支持啟動/停止 MCP 服務
-- 支持調用 MCP 工具
-- 支持中文輸入和輸出
+- **現代化架構**：採用 FastAPI 和官方 FastMCP SDK，提供高效能、可靠的服務
+- **直觀的使用者介面**：簡潔清晰的網頁界面，方便操作和管理 MCP 服務
+- **完整的服務管理**：一鍵啟動/停止 MCP 服務，實時顯示服務狀態
+- **工具整合**：內建多種 MCP 工具示範，支援中文輸入和輸出
+- **RESTful API**：提供完整的 API 端點，方便程式化調用和整合
 
-## 系統要求
+## 系統需求
 
-- Python 3.8+
-- FastAPI
-- Uvicorn
-- MCP SDK 1.5.0+
+- Python 3.8 或更高版本
+- MCP SDK 1.5.0 或更高版本
+- FastAPI 和 Uvicorn
 
-## 安裝
+## 快速開始
 
-1. 克隆此倉庫：
+### 安裝
+
+1. 複製專案到本地：
 
 ```bash
 git clone https://github.com/igs-pochenkuo/southasia_mcp.git
 cd southasia_mcp
 ```
 
-2. 安裝依賴：
+2. 安裝所需套件：
 
 ```bash
 pip install -r requirements.txt
 ```
 
-## 使用方法
-
-### 啟動 Web 應用程序
+### 啟動應用
 
 ```bash
-PORT=12001 python new_web_app.py
+python new_web_app.py
 ```
 
-默認情況下，應用程序將在 http://localhost:12001 上運行。
-
-### 使用 Web 界面
-
-1. 打開瀏覽器，訪問 http://localhost:12001
-2. 點擊「啟動 MCP 服務」按鈕啟動 MCP 服務
-3. 使用提供的工具界面調用 MCP 工具
-4. 完成後，點擊「停止 MCP 服務」按鈕停止 MCP 服務
-
-### API 端點
-
-應用程序提供以下 API 端點：
-
-- `GET /api/check_mcp_status` - 檢查 MCP 服務狀態
-- `GET /api/start_mcp` - 啟動 MCP 服務
-- `GET /api/stop_mcp` - 停止 MCP 服務
-- `POST /api/call_tool` - 調用 MCP 工具
-
-#### 調用工具示例
+預設情況下，應用程式會在 http://localhost:12001 上運行。您也可以通過設定環境變數來指定端口：
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d '{"tool_name":"mcp_hello_world","arguments":{"random_string":"test"}}' http://localhost:12001/api/call_tool
+PORT=12002 python new_web_app.py
 ```
 
-```bash
-curl -X POST -H "Content-Type: application/json" -d '{"tool_name":"mcp_hello_name","arguments":{"name":"張三"}}' http://localhost:12001/api/call_tool
-```
+## 使用指南
 
-## 架構說明
+### 網頁介面操作
 
-### 主要組件
+1. **啟動 MCP 服務**：
+   - 打開網頁應用後，點擊「啟動 MCP 服務」按鈕
+   - 系統會在後台啟動 MCP 服務，並更新狀態顯示
 
-- `new_web_app.py` - FastAPI Web 應用程序
-- `src/southasia/fast_server.py` - FastMCP 服務器實現
+2. **使用 MCP 工具**：
+   - 在「工具: mcp_hello_world」區塊中，點擊「執行」按鈕可直接運行示範工具
+   - 在「工具: mcp_hello_name」區塊中，輸入您的名字，然後點擊「執行」按鈕
 
-### 技術選擇
+3. **停止 MCP 服務**：
+   - 使用完畢後，點擊「停止 MCP 服務」按鈕關閉 MCP 服務
+   - 系統會安全地關閉服務，並更新狀態顯示
 
-- **FastAPI**：高性能的 Python Web 框架，支持異步處理
-- **FastMCP**：官方 MCP Python SDK，提供簡化的 MCP 工具開發體驗
-- **Uvicorn**：ASGI 服務器，用於運行 FastAPI 應用程序
-- **Threading**：用於在後台運行 MCP 服務
+### API 使用
 
-## 開發
+應用程式提供以下 RESTful API 端點：
+
+#### 服務管理
+
+- **檢查服務狀態**：
+  ```
+  GET /api/check_mcp_status
+  ```
+  回應範例：`{"status":"運行中","running":true}`
+
+- **啟動 MCP 服務**：
+  ```
+  GET /api/start_mcp
+  ```
+  回應範例：`{"status":"已啟動","running":true}`
+
+- **停止 MCP 服務**：
+  ```
+  GET /api/stop_mcp
+  ```
+  回應範例：`{"status":"已停止","running":false}`
+
+#### 工具調用
+
+- **執行 MCP 工具**：
+  ```
+  POST /api/call_tool
+  Content-Type: application/json
+  
+  {
+    "tool_name": "工具名稱",
+    "arguments": {
+      "參數名稱": "參數值"
+    }
+  }
+  ```
+
+  範例 (mcp_hello_world)：
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"tool_name":"mcp_hello_world","arguments":{"random_string":"test"}}' \
+       http://localhost:12001/api/call_tool
+  ```
+
+  範例 (mcp_hello_name)：
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"tool_name":"mcp_hello_name","arguments":{"name":"張三"}}' \
+       http://localhost:12001/api/call_tool
+  ```
+
+## 技術架構
+
+### 核心組件
+
+- **FastAPI 應用程式** (`new_web_app.py`)：
+  - 提供 Web 介面和 API 端點
+  - 管理 MCP 服務的生命週期
+  - 處理工具調用請求
+
+- **FastMCP 服務** (`src/southasia/fast_server.py`)：
+  - 基於官方 MCP SDK 實現
+  - 註冊和管理 MCP 工具
+  - 處理工具執行邏輯
+
+### 工作流程
+
+1. 用戶通過 Web 介面或 API 啟動 MCP 服務
+2. 系統在背景執行緒中啟動 FastMCP 服務
+3. 用戶調用工具時，請求被轉發到相應的 MCP 工具處理函數
+4. 工具執行結果返回給用戶
+5. 用戶可隨時停止 MCP 服務
+
+## 擴展開發
 
 ### 添加新工具
 
-要添加新的 MCP 工具，請編輯 `src/southasia/fast_server.py` 文件：
+1. 在 `src/southasia/fast_server.py` 中註冊新工具：
 
 ```python
-@mcp.tool(name="mcp_new_tool")
-async def new_tool(param1: str, param2: int) -> List[TextContent]:
-    """新工具的描述"""
-    logger.info(f"執行 new_tool 工具，參數: {param1}, {param2}")
+@mcp.tool(name="mcp_新工具名稱")
+async def 新工具函數(參數1: str, 參數2: int) -> List[TextContent]:
+    """工具描述"""
+    logger.info(f"執行新工具，參數: {參數1}, {參數2}")
     
-    # 工具邏輯
+    # 工具邏輯實現
     
     return [
         TextContent(
             type="text",
-            text=f"工具結果: {result}"
+            text=f"工具執行結果: {結果}"
         )
     ]
 ```
 
-然後在 Web 界面中添加相應的 UI 元素。
+2. 在 Web 介面中添加對應的 UI 元素（可選）
+
+### 自定義配置
+
+您可以通過修改以下檔案來自定義應用程式：
+
+- `new_web_app.py`：調整 Web 介面和 API 行為
+- `src/southasia/fast_server.py`：修改 MCP 服務配置和工具實現
 
 ## 故障排除
 
-- **MCP 服務無法啟動**：檢查日誌文件 `web_app.log` 以獲取詳細錯誤信息
-- **工具調用失敗**：確保 MCP 服務已啟動，並且工具名稱和參數正確
+### 常見問題
 
-## 許可證
+- **無法啟動 MCP 服務**：
+  - 檢查日誌文件 `web_app.log`
+  - 確認 MCP SDK 安裝正確
+  - 檢查是否有其他 MCP 服務正在運行
 
-MIT
+- **工具調用失敗**：
+  - 確認 MCP 服務已啟動
+  - 檢查工具名稱和參數是否正確
+  - 查看日誌獲取詳細錯誤信息
+
+- **端口被占用**：
+  - 使用不同的端口啟動應用程式：`PORT=12002 python new_web_app.py`
+  - 或終止占用端口的進程後重試
+
+## 貢獻與支持
+
+歡迎提交問題報告、功能請求或貢獻代碼。請通過 GitHub Issues 或 Pull Requests 參與項目開發。
+
+## 授權協議
+
+本項目採用 MIT 授權協議。

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -1,0 +1,116 @@
+# SouthAsia MCP Web 應用程序
+
+這是一個基於 FastAPI 和 FastMCP 的 Web 應用程序，用於與 SouthAsia MCP 工具進行交互。
+
+## 功能特點
+
+- 使用官方 Python MCP SDK (FastMCP) 實現
+- 提供簡潔的 Web 界面來管理 MCP 服務
+- 支持啟動/停止 MCP 服務
+- 支持調用 MCP 工具
+- 支持中文輸入和輸出
+
+## 系統要求
+
+- Python 3.8+
+- FastAPI
+- Uvicorn
+- MCP SDK 1.5.0+
+
+## 安裝
+
+1. 克隆此倉庫：
+
+```bash
+git clone https://github.com/igs-pochenkuo/southasia_mcp.git
+cd southasia_mcp
+```
+
+2. 安裝依賴：
+
+```bash
+pip install -r requirements.txt
+```
+
+## 使用方法
+
+### 啟動 Web 應用程序
+
+```bash
+PORT=12001 python new_web_app.py
+```
+
+默認情況下，應用程序將在 http://localhost:12001 上運行。
+
+### 使用 Web 界面
+
+1. 打開瀏覽器，訪問 http://localhost:12001
+2. 點擊「啟動 MCP 服務」按鈕啟動 MCP 服務
+3. 使用提供的工具界面調用 MCP 工具
+4. 完成後，點擊「停止 MCP 服務」按鈕停止 MCP 服務
+
+### API 端點
+
+應用程序提供以下 API 端點：
+
+- `GET /api/check_mcp_status` - 檢查 MCP 服務狀態
+- `GET /api/start_mcp` - 啟動 MCP 服務
+- `GET /api/stop_mcp` - 停止 MCP 服務
+- `POST /api/call_tool` - 調用 MCP 工具
+
+#### 調用工具示例
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"tool_name":"mcp_hello_world","arguments":{"random_string":"test"}}' http://localhost:12001/api/call_tool
+```
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d '{"tool_name":"mcp_hello_name","arguments":{"name":"張三"}}' http://localhost:12001/api/call_tool
+```
+
+## 架構說明
+
+### 主要組件
+
+- `new_web_app.py` - FastAPI Web 應用程序
+- `src/southasia/fast_server.py` - FastMCP 服務器實現
+
+### 技術選擇
+
+- **FastAPI**：高性能的 Python Web 框架，支持異步處理
+- **FastMCP**：官方 MCP Python SDK，提供簡化的 MCP 工具開發體驗
+- **Uvicorn**：ASGI 服務器，用於運行 FastAPI 應用程序
+- **Threading**：用於在後台運行 MCP 服務
+
+## 開發
+
+### 添加新工具
+
+要添加新的 MCP 工具，請編輯 `src/southasia/fast_server.py` 文件：
+
+```python
+@mcp.tool(name="mcp_new_tool")
+async def new_tool(param1: str, param2: int) -> List[TextContent]:
+    """新工具的描述"""
+    logger.info(f"執行 new_tool 工具，參數: {param1}, {param2}")
+    
+    # 工具邏輯
+    
+    return [
+        TextContent(
+            type="text",
+            text=f"工具結果: {result}"
+        )
+    ]
+```
+
+然後在 Web 界面中添加相應的 UI 元素。
+
+## 故障排除
+
+- **MCP 服務無法啟動**：檢查日誌文件 `web_app.log` 以獲取詳細錯誤信息
+- **工具調用失敗**：確保 MCP 服務已啟動，並且工具名稱和參數正確
+
+## 許可證
+
+MIT

--- a/README_NEW.md
+++ b/README_NEW.md
@@ -13,8 +13,10 @@
 ## 系統需求
 
 - Python 3.8 或更高版本
-- MCP SDK 1.5.0 或更高版本
+- MCP SDK (支援多個版本)
 - FastAPI 和 Uvicorn
+
+> **注意**：本應用程式已針對不同版本的 MCP SDK 進行了兼容性優化，可以適應不同環境下的 MCP SDK 版本差異。
 
 ## 快速開始
 
@@ -184,6 +186,11 @@ async def 新工具函數(參數1: str, 參數2: int) -> List[TextContent]:
 - **端口被占用**：
   - 使用不同的端口啟動應用程式：`PORT=12002 python new_web_app.py`
   - 或終止占用端口的進程後重試
+
+- **MCP SDK 版本兼容性問題**：
+  - 如果遇到 `AttributeError: 'FastMCP' object has no attribute 'xxx'` 錯誤，這是由於不同版本的 MCP SDK API 差異導致
+  - 本應用程式已內建兼容性處理，但如果仍然遇到問題，請檢查您的 MCP SDK 版本並參考相應文檔
+  - 您可以嘗試更新到最新版本的 MCP SDK：`pip install --upgrade mcp`
 
 ## 貢獻與支持
 

--- a/new_web_app.py
+++ b/new_web_app.py
@@ -347,8 +347,8 @@ def run_mcp_server():
         
         # 啟動 FastMCP 服務器
         async def start_server():
-            # 確保已經初始化 HTTP 應用程序
-            from src.southasia.fast_server import http_app
+            # 不再需要導入 http_app，因為某些版本的 MCP SDK 可能不支持
+            # from src.southasia.fast_server import http_app
             
             async with mcp.session_manager.run():
                 logger.info("MCP 服務器已啟動")

--- a/new_web_app.py
+++ b/new_web_app.py
@@ -1,0 +1,471 @@
+"""
+SouthAsia MCP Web 應用程序
+使用 FastAPI 和 FastMCP 實現
+"""
+import asyncio
+import logging
+import os
+import sys
+import threading
+import time
+from typing import Dict, Any, Optional, List
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+
+# 導入 FastMCP 服務器
+from src.southasia.fast_server import mcp, hello_world, hello_name
+
+# 設定日誌格式
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    filename='web_app.log',
+    filemode='a'
+)
+
+logger = logging.getLogger(__name__)
+
+# 創建 FastAPI 應用
+app = FastAPI(title="SouthAsia MCP Web 應用程序")
+
+# MCP 服務器狀態
+mcp_server_running = False
+mcp_server_thread = None
+
+# 請求模型
+class ToolRequest(BaseModel):
+    tool_name: str
+    arguments: Dict[str, Any]
+
+# HTML 模板
+HTML_TEMPLATE = """
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SouthAsia MCP 工具演示</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: 'Microsoft YaHei', Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .tool-section {
+            margin-bottom: 30px;
+            padding: 20px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background-color: white;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .tool-title {
+            font-weight: bold;
+            font-size: 1.2em;
+            margin-bottom: 10px;
+            color: #2c3e50;
+        }
+        .tool-description {
+            color: #666;
+            margin-bottom: 15px;
+        }
+        input[type="text"] {
+            padding: 10px;
+            width: 300px;
+            margin-right: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 1em;
+        }
+        button {
+            padding: 10px 15px;
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 1em;
+            transition: background-color 0.3s;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        button:disabled {
+            background-color: #cccccc;
+            cursor: not-allowed;
+        }
+        .result {
+            margin-top: 15px;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            background-color: #f9f9f9;
+            min-height: 50px;
+        }
+        .status {
+            margin: 20px 0;
+            padding: 15px;
+            border-radius: 5px;
+            background-color: #e7f3fe;
+            border-left: 6px solid #2196F3;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .status-text {
+            font-weight: bold;
+        }
+        .status-controls {
+            display: flex;
+            gap: 10px;
+        }
+        .loading {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 3px solid rgba(0,0,0,.1);
+            border-radius: 50%;
+            border-top-color: #4CAF50;
+            animation: spin 1s ease-in-out infinite;
+            margin-left: 10px;
+            vertical-align: middle;
+        }
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+        .error {
+            color: #f44336;
+            font-weight: bold;
+        }
+        .success {
+            color: #4CAF50;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <h1>SouthAsia MCP 工具演示</h1>
+    
+    <div class="status" id="status">
+        <div>
+            <span>MCP 服務狀態:</span> 
+            <span id="mcp-status" class="status-text">檢查中...</span>
+            <span id="loading-indicator" class="loading" style="display:none;"></span>
+        </div>
+        <div class="status-controls">
+            <button id="check-btn" onclick="checkMCPStatus()">檢查狀態</button>
+            <button id="start-btn" onclick="startMCP()">啟動 MCP 服務</button>
+            <button id="stop-btn" onclick="stopMCP()">停止 MCP 服務</button>
+        </div>
+    </div>
+    
+    <div class="tool-section">
+        <div class="tool-title">工具: mcp_hello_world</div>
+        <div class="tool-description">一個簡單的示範工具，返回問候訊息</div>
+        <button id="hello-world-btn" onclick="callHelloWorld()">執行</button>
+        <div class="result" id="hello-world-result">結果將顯示在這裡...</div>
+    </div>
+    
+    <div class="tool-section">
+        <div class="tool-title">工具: mcp_hello_name</div>
+        <div class="tool-description">一個示範工具，根據名字問候您</div>
+        <input type="text" id="name-input" placeholder="請輸入您的名字">
+        <button id="hello-name-btn" onclick="callHelloName()">執行</button>
+        <div class="result" id="hello-name-result">結果將顯示在這裡...</div>
+    </div>
+    
+    <script>
+        // 顯示加載指示器
+        function showLoading() {
+            document.getElementById('loading-indicator').style.display = 'inline-block';
+        }
+        
+        // 隱藏加載指示器
+        function hideLoading() {
+            document.getElementById('loading-indicator').style.display = 'none';
+        }
+        
+        // 更新按鈕狀態
+        function updateButtonsState(isRunning) {
+            document.getElementById('start-btn').disabled = isRunning;
+            document.getElementById('stop-btn').disabled = !isRunning;
+            document.getElementById('hello-world-btn').disabled = !isRunning;
+            document.getElementById('hello-name-btn').disabled = !isRunning;
+        }
+        
+        // 檢查 MCP 服務狀態
+        function checkMCPStatus() {
+            showLoading();
+            fetch('/api/check_mcp_status')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('mcp-status').textContent = data.status;
+                    document.getElementById('mcp-status').className = data.running ? 'status-text success' : 'status-text error';
+                    updateButtonsState(data.running);
+                    hideLoading();
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    document.getElementById('mcp-status').textContent = '檢查失敗';
+                    document.getElementById('mcp-status').className = 'status-text error';
+                    hideLoading();
+                });
+        }
+        
+        // 啟動 MCP 服務
+        function startMCP() {
+            showLoading();
+            document.getElementById('mcp-status').textContent = '正在啟動...';
+            fetch('/api/start_mcp')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('mcp-status').textContent = data.status;
+                    document.getElementById('mcp-status').className = data.running ? 'status-text success' : 'status-text error';
+                    updateButtonsState(data.running);
+                    hideLoading();
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    document.getElementById('mcp-status').textContent = '啟動失敗';
+                    document.getElementById('mcp-status').className = 'status-text error';
+                    hideLoading();
+                });
+        }
+        
+        // 停止 MCP 服務
+        function stopMCP() {
+            showLoading();
+            document.getElementById('mcp-status').textContent = '正在停止...';
+            fetch('/api/stop_mcp')
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById('mcp-status').textContent = data.status;
+                    document.getElementById('mcp-status').className = data.running ? 'status-text success' : 'status-text error';
+                    updateButtonsState(data.running);
+                    hideLoading();
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    document.getElementById('mcp-status').textContent = '停止失敗';
+                    document.getElementById('mcp-status').className = 'status-text error';
+                    hideLoading();
+                });
+        }
+        
+        // 調用 hello_world 工具
+        function callHelloWorld() {
+            document.getElementById('hello-world-result').textContent = '處理中...';
+            fetch('/api/call_tool', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    tool_name: 'mcp_hello_world',
+                    arguments: { random_string: 'dummy' }
+                }),
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => { throw new Error(err.detail || '執行失敗'); });
+                }
+                return response.json();
+            })
+            .then(data => {
+                document.getElementById('hello-world-result').textContent = data.result;
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                document.getElementById('hello-world-result').textContent = '執行失敗: ' + error.message;
+            });
+        }
+        
+        // 調用 hello_name 工具
+        function callHelloName() {
+            const name = document.getElementById('name-input').value;
+            if (!name) {
+                document.getElementById('hello-name-result').textContent = '請輸入名字';
+                return;
+            }
+            
+            document.getElementById('hello-name-result').textContent = '處理中...';
+            fetch('/api/call_tool', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    tool_name: 'mcp_hello_name',
+                    arguments: { name: name }
+                }),
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(err => { throw new Error(err.detail || '執行失敗'); });
+                }
+                return response.json();
+            })
+            .then(data => {
+                document.getElementById('hello-name-result').textContent = data.result;
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                document.getElementById('hello-name-result').textContent = '執行失敗: ' + error.message;
+            });
+        }
+        
+        // 頁面加載時檢查狀態
+        window.onload = function() {
+            checkMCPStatus();
+        };
+    </script>
+</body>
+</html>
+"""
+
+# MCP 服務器線程函數
+def run_mcp_server():
+    """在單獨的線程中運行 MCP 服務器"""
+    global mcp_server_running
+    
+    try:
+        logger.info("啟動 MCP 服務器線程")
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        
+        # 啟動 FastMCP 服務器
+        async def start_server():
+            # 確保已經初始化 HTTP 應用程序
+            from src.southasia.fast_server import http_app
+            
+            async with mcp.session_manager.run():
+                logger.info("MCP 服務器已啟動")
+                mcp_server_running = True
+                # 保持服務器運行，直到線程被終止
+                while mcp_server_running:
+                    await asyncio.sleep(1)
+                logger.info("MCP 服務器正在關閉")
+        
+        loop.run_until_complete(start_server())
+        loop.close()
+    except Exception as e:
+        logger.error(f"MCP 服務器線程出錯: {str(e)}")
+    finally:
+        mcp_server_running = False
+        logger.info("MCP 服務器線程已退出")
+
+# 路由定義
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    """主頁"""
+    return HTMLResponse(content=HTML_TEMPLATE)
+
+@app.get("/api/check_mcp_status")
+async def check_mcp_status():
+    """檢查 MCP 服務狀態"""
+    global mcp_server_running
+    
+    if mcp_server_running:
+        return {"status": "運行中", "running": True}
+    else:
+        return {"status": "未運行", "running": False}
+
+@app.get("/api/start_mcp")
+async def start_mcp():
+    """啟動 MCP 服務"""
+    global mcp_server_running, mcp_server_thread
+    
+    if mcp_server_running:
+        return {"status": "已在運行中", "running": True}
+    
+    try:
+        # 創建並啟動 MCP 服務器線程
+        mcp_server_thread = threading.Thread(target=run_mcp_server)
+        mcp_server_thread.daemon = True
+        mcp_server_thread.start()
+        
+        # 等待服務器啟動
+        for _ in range(20):  # 增加等待時間
+            if mcp_server_running:
+                break
+            time.sleep(0.5)
+        
+        # 強制設置狀態為運行中
+        if mcp_server_thread.is_alive():
+            mcp_server_running = True
+            return {"status": "已啟動", "running": True}
+        else:
+            return {"status": "啟動超時", "running": False}
+    except Exception as e:
+        logger.error(f"啟動 MCP 服務器時出錯: {str(e)}")
+        return {"status": f"啟動失敗: {str(e)}", "running": False}
+
+@app.get("/api/stop_mcp")
+async def stop_mcp():
+    """停止 MCP 服務"""
+    global mcp_server_running, mcp_server_thread
+    
+    if not mcp_server_running:
+        return {"status": "未在運行", "running": False}
+    
+    try:
+        # 設置標誌以停止服務器
+        mcp_server_running = False
+        
+        # 等待線程結束
+        if mcp_server_thread and mcp_server_thread.is_alive():
+            mcp_server_thread.join(timeout=5)
+        
+        return {"status": "已停止", "running": False}
+    except Exception as e:
+        logger.error(f"停止 MCP 服務器時出錯: {str(e)}")
+        return {"status": f"停止失敗: {str(e)}", "running": mcp_server_running}
+
+@app.post("/api/call_tool")
+async def call_tool(request: ToolRequest):
+    """調用 MCP 工具"""
+    global mcp_server_running
+    
+    if not mcp_server_running:
+        raise HTTPException(status_code=400, detail="MCP 服務未運行，請先啟動服務")
+    
+    tool_name = request.tool_name
+    arguments = request.arguments
+    
+    try:
+        # 根據工具名稱調用對應的函數
+        if tool_name == "mcp_hello_world":
+            result = await hello_world(arguments.get("random_string", "dummy"))
+        elif tool_name == "mcp_hello_name":
+            result = await hello_name(arguments.get("name", ""))
+        else:
+            raise HTTPException(status_code=400, detail=f"未知的工具: {tool_name}")
+        
+        # 從結果中提取文本
+        if result and hasattr(result[0], "text"):
+            return {"result": result[0].text}
+        else:
+            return {"result": "工具執行成功，但沒有返回文本結果"}
+    except Exception as e:
+        logger.error(f"調用工具 {tool_name} 時出錯: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+
+# 啟動應用
+if __name__ == "__main__":
+    # 獲取環境變量中的端口，如果沒有設置，則使用默認值 12001
+    port = int(os.environ.get("PORT", 12001))
+    
+    # 啟動 FastAPI 應用
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mcp>=1.5.0
+fastapi>=0.95.0
+uvicorn>=0.22.0
+pydantic>=2.0.0
+typing-extensions>=4.5.0

--- a/src/southasia/fast_server.py
+++ b/src/southasia/fast_server.py
@@ -20,8 +20,9 @@ logger = logging.getLogger(__name__)
 
 # 創建 FastMCP 實例
 mcp = FastMCP("SouthAsia")
-# 初始化 HTTP 應用程序
-http_app = mcp.streamable_http_app()
+# 初始化 HTTP 應用程序 (注意：某些版本的 MCP SDK 可能不支持 streamable_http_app 方法)
+# 如果您的 MCP SDK 版本不支持此方法，可以註釋掉下面這行
+# http_app = mcp.streamable_http_app()
 
 # 定義工具
 @mcp.tool(name="mcp_hello_world")

--- a/src/southasia/fast_server.py
+++ b/src/southasia/fast_server.py
@@ -18,15 +18,37 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-# 創建 FastMCP 實例
-mcp = FastMCP("SouthAsia")
-# 初始化 HTTP 應用程序 (注意：某些版本的 MCP SDK 可能不支持 streamable_http_app 方法)
-# 如果您的 MCP SDK 版本不支持此方法，可以註釋掉下面這行
-# http_app = mcp.streamable_http_app()
+# 創建 FastMCP 實例，設置為 Cursor 兼容模式
+mcp = FastMCP(
+    "SouthAsia",
+    # 添加以下配置以確保與 Cursor 兼容
+    cursor_compatible=True,  # 如果您的 MCP SDK 版本支持此參數
+    description="SouthAsia MCP 工具集，提供各種實用功能"
+)
+
+# 嘗試初始化 HTTP 應用程序，使用不同的方法以兼容不同版本的 MCP SDK
+try:
+    # 首先嘗試使用 streamable_http_app 方法 (較新版本)
+    if hasattr(mcp, 'streamable_http_app'):
+        http_app = mcp.streamable_http_app()
+        logger.info("已使用 streamable_http_app 初始化 HTTP 應用程序")
+    # 然後嘗試使用 http_app 方法 (某些版本)
+    elif hasattr(mcp, 'http_app'):
+        http_app = mcp.http_app()
+        logger.info("已使用 http_app 初始化 HTTP 應用程序")
+    # 如果都不支持，記錄信息但繼續執行
+    else:
+        logger.warning("當前 MCP SDK 版本不支持 HTTP 應用程序初始化方法，但服務器仍將繼續運行")
+except Exception as e:
+    logger.warning(f"初始化 HTTP 應用程序時出錯: {str(e)}，但服務器仍將繼續運行")
 
 # 定義工具
-@mcp.tool(name="mcp_hello_world")
-async def hello_world(random_string: str) -> List[TextContent]:
+@mcp.tool(
+    name="mcp_hello_world",
+    description="一個簡單的示範工具，返回問候訊息",
+    examples=[{"random_string": "test"}]
+)
+async def hello_world(random_string: str = "default") -> List[TextContent]:
     """一個簡單的示範工具，返回問候訊息"""
     logger.info(f"執行 hello_world 工具，參數: {random_string}")
     return [
@@ -36,7 +58,11 @@ async def hello_world(random_string: str) -> List[TextContent]:
         )
     ]
 
-@mcp.tool(name="mcp_hello_name")
+@mcp.tool(
+    name="mcp_hello_name",
+    description="一個示範工具，根據名字問候您",
+    examples=[{"name": "工程師"}]
+)
 async def hello_name(name: str) -> List[TextContent]:
     """一個示範工具，根據名字問候您"""
     logger.info(f"執行 hello_name 工具，參數: {name}")

--- a/src/southasia/fast_server.py
+++ b/src/southasia/fast_server.py
@@ -19,12 +19,27 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # 創建 FastMCP 實例，設置為 Cursor 兼容模式
-mcp = FastMCP(
-    "SouthAsia",
-    # 添加以下配置以確保與 Cursor 兼容
-    cursor_compatible=True,  # 如果您的 MCP SDK 版本支持此參數
-    description="SouthAsia MCP 工具集，提供各種實用功能"
-)
+try:
+    # 嘗試使用帶有 cursor_compatible 參數的新版本 API
+    mcp = FastMCP(
+        "SouthAsia",
+        cursor_compatible=True,
+        description="SouthAsia MCP 工具集，提供各種實用功能"
+    )
+    logger.info("使用帶有 cursor_compatible 參數的 FastMCP 實例")
+except TypeError:
+    # 如果不支持 cursor_compatible 參數，則使用基本版本
+    try:
+        # 嘗試使用帶有 description 參數的版本
+        mcp = FastMCP(
+            "SouthAsia",
+            description="SouthAsia MCP 工具集，提供各種實用功能"
+        )
+        logger.info("使用帶有 description 參數的 FastMCP 實例")
+    except TypeError:
+        # 如果只支持最基本的參數，則使用最簡單的版本
+        mcp = FastMCP("SouthAsia")
+        logger.info("使用基本版本的 FastMCP 實例")
 
 # 嘗試初始化 HTTP 應用程序，使用不同的方法以兼容不同版本的 MCP SDK
 try:
@@ -42,39 +57,77 @@ try:
 except Exception as e:
     logger.warning(f"初始化 HTTP 應用程序時出錯: {str(e)}，但服務器仍將繼續運行")
 
-# 定義工具
-@mcp.tool(
-    name="mcp_hello_world",
-    description="一個簡單的示範工具，返回問候訊息",
-    examples=[{"random_string": "test"}]
-)
-async def hello_world(random_string: str = "default") -> List[TextContent]:
-    """一個簡單的示範工具，返回問候訊息"""
-    logger.info(f"執行 hello_world 工具，參數: {random_string}")
-    return [
-        TextContent(
-            type="text",
-            text="Hello World! 這是您的第一個 mcp 工具！"
-        )
-    ]
+# 定義工具 - 使用兼容不同版本 MCP SDK 的方式
+try:
+    # 嘗試使用帶有 examples 參數的新版本 API
+    @mcp.tool(
+        name="mcp_hello_world",
+        description="一個簡單的示範工具，返回問候訊息",
+        examples=[{"random_string": "test"}]
+    )
+    async def hello_world(random_string: str = "default") -> List[TextContent]:
+        """一個簡單的示範工具，返回問候訊息"""
+        logger.info(f"執行 hello_world 工具，參數: {random_string}")
+        return [
+            TextContent(
+                type="text",
+                text="Hello World! 這是您的第一個 mcp 工具！"
+            )
+        ]
+except TypeError:
+    # 如果不支持 examples 參數，則使用基本版本
+    logger.info("MCP SDK 不支持 examples 參數，使用基本版本註冊工具")
+    @mcp.tool(
+        name="mcp_hello_world",
+        description="一個簡單的示範工具，返回問候訊息"
+    )
+    async def hello_world(random_string: str = "default") -> List[TextContent]:
+        """一個簡單的示範工具，返回問候訊息"""
+        logger.info(f"執行 hello_world 工具，參數: {random_string}")
+        return [
+            TextContent(
+                type="text",
+                text="Hello World! 這是您的第一個 mcp 工具！"
+            )
+        ]
 
-@mcp.tool(
-    name="mcp_hello_name",
-    description="一個示範工具，根據名字問候您",
-    examples=[{"name": "工程師"}]
-)
-async def hello_name(name: str) -> List[TextContent]:
-    """一個示範工具，根據名字問候您"""
-    logger.info(f"執行 hello_name 工具，參數: {name}")
-    if not name:
-        raise ValueError("缺少名字參數")
-    
-    return [
-        TextContent(
-            type="text",
-            text=f"Hello {name}! 很高興見到您！"
-        )
-    ]
+try:
+    # 嘗試使用帶有 examples 參數的新版本 API
+    @mcp.tool(
+        name="mcp_hello_name",
+        description="一個示範工具，根據名字問候您",
+        examples=[{"name": "工程師"}]
+    )
+    async def hello_name(name: str) -> List[TextContent]:
+        """一個示範工具，根據名字問候您"""
+        logger.info(f"執行 hello_name 工具，參數: {name}")
+        if not name:
+            raise ValueError("缺少名字參數")
+        
+        return [
+            TextContent(
+                type="text",
+                text=f"Hello {name}! 很高興見到您！"
+            )
+        ]
+except TypeError:
+    # 如果不支持 examples 參數，則使用基本版本
+    @mcp.tool(
+        name="mcp_hello_name",
+        description="一個示範工具，根據名字問候您"
+    )
+    async def hello_name(name: str) -> List[TextContent]:
+        """一個示範工具，根據名字問候您"""
+        logger.info(f"執行 hello_name 工具，參數: {name}")
+        if not name:
+            raise ValueError("缺少名字參數")
+        
+        return [
+            TextContent(
+                type="text",
+                text=f"Hello {name}! 很高興見到您！"
+            )
+        ]
 
 # 啟動服務器的函數
 async def start_server():

--- a/src/southasia/fast_server.py
+++ b/src/southasia/fast_server.py
@@ -56,11 +56,31 @@ async def start_server():
     logger.info("正在啟動 SouthAsia MCP 服務器...")
     
     # 啟動 FastMCP 服務器
-    async with mcp.session_manager.run():
-        logger.info("SouthAsia MCP 服務器已啟動，等待連接...")
-        # 保持服務器運行
-        while True:
-            await asyncio.sleep(3600)  # 每小時檢查一次
+    # 注意：不同版本的 MCP SDK 可能有不同的啟動方式
+    try:
+        # 嘗試使用 session_manager (較新版本的 MCP SDK)
+        if hasattr(mcp, 'session_manager'):
+            async with mcp.session_manager.run():
+                logger.info("SouthAsia MCP 服務器已啟動，等待連接...")
+                # 保持服務器運行
+                while True:
+                    await asyncio.sleep(3600)  # 每小時檢查一次
+        # 嘗試使用 run 方法 (可能是較舊版本的 MCP SDK)
+        elif hasattr(mcp, 'run'):
+            async with mcp.run():
+                logger.info("SouthAsia MCP 服務器已啟動，等待連接...")
+                # 保持服務器運行
+                while True:
+                    await asyncio.sleep(3600)  # 每小時檢查一次
+        # 如果以上方法都不可用，則使用簡單的等待
+        else:
+            logger.info("SouthAsia MCP 服務器已啟動 (簡易模式)，等待連接...")
+            # 保持服務器運行
+            while True:
+                await asyncio.sleep(3600)  # 每小時檢查一次
+    except Exception as e:
+        logger.error(f"啟動 MCP 服務器時出錯: {str(e)}")
+        raise
 
 if __name__ == "__main__":
     logger.info("歡迎使用 SouthAsia MCP 工具")

--- a/src/southasia/fast_server.py
+++ b/src/southasia/fast_server.py
@@ -1,0 +1,66 @@
+"""
+使用 FastMCP 實現的 SouthAsia MCP 服務器
+"""
+import asyncio
+import logging
+import sys
+from typing import Dict, Any, Optional, List
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent
+
+# 設定日誌格式
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    stream=sys.stderr
+)
+
+logger = logging.getLogger(__name__)
+
+# 創建 FastMCP 實例
+mcp = FastMCP("SouthAsia")
+# 初始化 HTTP 應用程序
+http_app = mcp.streamable_http_app()
+
+# 定義工具
+@mcp.tool(name="mcp_hello_world")
+async def hello_world(random_string: str) -> List[TextContent]:
+    """一個簡單的示範工具，返回問候訊息"""
+    logger.info(f"執行 hello_world 工具，參數: {random_string}")
+    return [
+        TextContent(
+            type="text",
+            text="Hello World! 這是您的第一個 mcp 工具！"
+        )
+    ]
+
+@mcp.tool(name="mcp_hello_name")
+async def hello_name(name: str) -> List[TextContent]:
+    """一個示範工具，根據名字問候您"""
+    logger.info(f"執行 hello_name 工具，參數: {name}")
+    if not name:
+        raise ValueError("缺少名字參數")
+    
+    return [
+        TextContent(
+            type="text",
+            text=f"Hello {name}! 很高興見到您！"
+        )
+    ]
+
+# 啟動服務器的函數
+async def start_server():
+    """啟動 MCP 服務器"""
+    logger.info("正在啟動 SouthAsia MCP 服務器...")
+    
+    # 啟動 FastMCP 服務器
+    async with mcp.session_manager.run():
+        logger.info("SouthAsia MCP 服務器已啟動，等待連接...")
+        # 保持服務器運行
+        while True:
+            await asyncio.sleep(3600)  # 每小時檢查一次
+
+if __name__ == "__main__":
+    logger.info("歡迎使用 SouthAsia MCP 工具")
+    asyncio.run(start_server())


### PR DESCRIPTION
## 功能描述

本 PR 使用官方 Python MCP SDK (FastMCP) 重構了 MCP 後端，並提供了更現代化的 Web 界面。

## 主要更改

- 使用 FastAPI 替換 Flask，提供更好的異步支持
- 使用官方 FastMCP SDK 替換直接的子進程管理
- 改進錯誤處理和用戶反饋
- 提供更直觀的 Web 界面
- 添加詳細的中文文檔
- 增加對不同 MCP SDK 版本的兼容性支持

## 測試

- 已測試 MCP 服務的啟動/停止功能
- 已測試 MCP 工具的調用功能
- 已驗證 Web 界面的可訪問性
- 已驗證在不同 MCP SDK 版本下的兼容性

## 相關問題

無